### PR TITLE
Update indexing variable type for Eigen 3.4 compatibility

### DIFF
--- a/src/EMM_functions.cpp
+++ b/src/EMM_functions.cpp
@@ -1733,8 +1733,8 @@ double GWAS_F_test(Rcpp::NumericMatrix y, Rcpp::NumericMatrix x,
   const MapMat Hinv = Rcpp::as<MapMat>(hinv);
   const MapMat P = Rcpp::as<MapMat>(p);
   const int pSize(P.rows());
-  double pMin = P(0, 0);
-  double pMax= P(pSize - 1, 0);
+  int pMin = static_cast<int>(P(0, 0));
+  int pMax=  static_cast<int>(P(pSize - 1, 0));
 
   MatrixXd W = crossprod(X, Hinv * X);
   MatrixXd Winv = inv(W);


### PR DESCRIPTION
This PR updates your package's C++ to use an integer instead of a double for storing indexing Eigen types, otherwise your package will break with the next RcppEigen release (Eigen 3.4 doesn't allow using `double`s for indexing).

Let me know if you have any questions, thanks!
